### PR TITLE
New features: Max supply, Total_balance, withdraw, upgradable

### DIFF
--- a/contracts/pinkpsp34/minting/minting.rs
+++ b/contracts/pinkpsp34/minting/minting.rs
@@ -34,16 +34,21 @@ where
     /// Mint one token to the specified account.
     #[modifiers(only_owner)]
     default fn mint(&mut self, to: AccountId, metadata: String) -> Result<Id, Error> {
-        ink::env::debug_println!("PinkMint::pink_mint {:?} {:?}", to, metadata);
         self._check_amount(1)?;
         let minted_id = self._mint(to)?;
-        ink::env::debug_println!("PSPMint minted_id {:?}", minted_id);
 
         self.data::<MintingData>()
             .nft_metadata
             .insert(minted_id.clone(), &metadata);
 
         Ok(minted_id)
+    }
+
+    /// Get max supply of tokens.
+    #[modifiers(only_owner)]
+    default fn set_max_supply(&mut self, max_supply: Option<u64>) -> Result<(), Error> {
+        self.data::<MintingData>().max_supply = max_supply;
+        Ok(())
     }
 
     /// Get max supply of tokens.

--- a/contracts/pinkpsp34/minting/traits.rs
+++ b/contracts/pinkpsp34/minting/traits.rs
@@ -18,6 +18,10 @@ pub trait PinkMint {
     #[ink(message)]
     fn mint(&mut self, to: AccountId, metadata: String) -> Result<Id, Error>;
 
+    /// Set max supply of tokens.
+    #[ink(message)]
+    fn set_max_supply(&mut self, max_supply: Option<u64>) -> Result<(), Error>;
+
     /// Get max supply of tokens.
     #[ink(message)]
     fn max_supply(&self) -> Option<u64>;

--- a/frontend/src/const/index.ts
+++ b/frontend/src/const/index.ts
@@ -16,7 +16,7 @@ export const endpoint = "wss://rpc.shibuya.astar.network";
 export const BN_ZERO = new BN(0);
 
 export const contractAddress =
-  "X7oW2aZHThoXG9GyurDgfgieXfquDJ6znWnMDxfUsNrodba";
+  "ZCtoYmcJ2wwkZoFyejydTLrZj12roZzXHh5St7BTuJ78fRa";
 
 export const dryRunCallerAddress =
   "5DPDFJi6rcooALEpR5gSbR8jgUU6YerEHRkAv3Sk8MDoRTke";


### PR DESCRIPTION
- [x] `max_supply` can now be changed from Pinkrobot.  If supply is set to `None` the supply is endless
- [x] `pub fn total_balance(&self, holder: AccountId) -> Vec<Id>`. Returns vector of items owned by given user
- [x] `withdraw()` for owner of pinkrobot
- [x] contract is upgradeble with [set_code_hash()](https://use.ink/basics/upgradeable-contracts#replacing-contract-code-with-set_code_hash)
- [x] ink_e2e test