### PR TITLE
Fixed black hole image handling

### DIFF
--- a/frontend/src/components/GenerateForm.tsx
+++ b/frontend/src/components/GenerateForm.tsx
@@ -161,7 +161,7 @@ export const GenerateForm = ({
       const contentType = response.headers["content-type"];
       console.log("------- response.data", response.data);
       const isValidImage =
-        response.data.maxByteLength > BLACK_HOLE_IMAGE_MAX_SIZE;
+        response.data.byteLength > BLACK_HOLE_IMAGE_MAX_SIZE;
       if (isValidImage) {
         const base64data = Buffer.from(response.data).toString("base64");
         const aiImage = `data:${contentType};base64,` + base64data;


### PR DESCRIPTION
On some systems for unknown reason `maxByteLength` was not set. That explains that some people were unable to generate a token.