### PR TITLE
Hide loader when user cancels transaction in signer

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -52,7 +52,7 @@ body {
 }
 
 .accounts-dropdown {
-  @apply w-48;
+  @apply w-36;
 }
 
 .tweet {

--- a/frontend/src/components/PinkContainer.tsx
+++ b/frontend/src/components/PinkContainer.tsx
@@ -39,7 +39,7 @@ export const PinkContainer = () => {
 
           try {
             setBusyMessage(`Minting your NFT on ${connectedNetwork}...`);
-            await submitFn(values, helpers);
+            await submitFn(values, helpers, notBusyAnymore);
           } catch (err: any) {
             setError(err.toString());
             notBusyAnymore();

--- a/frontend/src/hooks/useMintHandler.ts
+++ b/frontend/src/hooks/useMintHandler.ts
@@ -16,7 +16,8 @@ export const useMintHandler = () => {
 
   return async (
     values: PinkValues,
-    { setSubmitting, setStatus }: FormikHelpers<PinkValues>
+    { setSubmitting, setStatus }: FormikHelpers<PinkValues>,
+    notBusyAnymore: () => void
   ) => {
 
     const getTokenId = async (values: PinkValues) => {
@@ -86,6 +87,7 @@ export const useMintHandler = () => {
       if (error) {
         console.error(JSON.stringify(error));
         setSubmitting(false);
+        notBusyAnymore();
       }
       console.log("Mint Tx", result?.status.toHuman());
 


### PR DESCRIPTION
Fixes behaviour when loader stays displayed after users cancels transaction