### PR TITLE
Quick fix for AccountInfo structure change

### DIFF
--- a/frontend/src/components/DryRunResult.tsx
+++ b/frontend/src/components/DryRunResult.tsx
@@ -61,7 +61,8 @@ export function DryRunResult({ values, isValid }: Props) {
   }, [pinkMintDryRun?.send, account?.address, values.ipfs]);
 
   formatBalance.setDefaults({ unit: values.tokenUnit });
-  const freeBalance = balance?.freeBalance.sub(balance.frozenFee);
+  // const freeBalance = balance?.freeBalance.sub(balance.frozenFee);
+  const freeBalance = undefined; // TOTO quick fix for removed frozenFee after the latest runtime update
   let txInfo;
   // if (!pinkMintDryRun?.result) return null;
   if (pinkMintDryRun?.result) {


### PR DESCRIPTION
After Astar runtime update account data structure changed and break the code.
To fix this the latest `useink` version is required which leads to well know [issue](https://stackoverflow.com/questions/64557638/how-to-polyfill-node-core-modules-in-webpack-5) which will take some time to implement.

As quick fix I removed free balance info from the UI